### PR TITLE
Splitting Compat Type Shifts

### DIFF
--- a/GetItemLink/GetItemLink.cs
+++ b/GetItemLink/GetItemLink.cs
@@ -6,6 +6,7 @@ using FrooxEngine.UIX;
 using Elements.Core;
 using System.Reflection;
 using System;
+using Renderite.Shared;
 
 namespace GetItemLink
 {

--- a/GetItemLink/GetItemLink.cs
+++ b/GetItemLink/GetItemLink.cs
@@ -14,7 +14,7 @@ namespace GetItemLink
     {
         public override string Name => "GetItemLink";
         public override string Author => "eia485";
-        public override string Version => "1.4.5";
+        public override string Version => "1.4.6";
         public override string Link => "https://github.com/eia485/NeosGetItemLink/";
         public override void OnEngineInit()
         {

--- a/GetItemLink/GetItemLink.csproj
+++ b/GetItemLink/GetItemLink.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>GetItemLink</RootNamespace>
     <AssemblyName>GetItemLink</AssemblyName>
     <ProjectGuid>{0322B2EF-7452-479D-BAE2-FCAB75033337}</ProjectGuid>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <BaseOutputPath>..\bin</BaseOutputPath>
     <BuildProjectReferences>false</BuildProjectReferences>
@@ -33,22 +33,25 @@
       <HintPath>$(HarmonyPath)</HintPath>
     </Reference>
     <Reference Include="SkyFrost.Base">
-      <HintPath>$(GameRefsPath)SkyFrost.Base.dll</HintPath>
+      <HintPath>$(GamePath)SkyFrost.Base.dll</HintPath>
     </Reference>
 	<Reference Include="Skyfrost.Base.Models">
-		<HintPath>$(GameRefsPath)Skyfrost.Base.Models.dll</HintPath>
+		<HintPath>$(GamePath)Skyfrost.Base.Models.dll</HintPath>
 	</Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(GameRefsPath)Assembly-CSharp.dll</HintPath>
+      <HintPath>$(GamePath)Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>$(GameRefsPath)FrooxEngine.dll</HintPath>
+      <HintPath>$(GamePath)FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine.Store">
-	  <HintPath>$(GameRefsPath)FrooxEngine.Store.dll</HintPath>
+	  <HintPath>$(GamePath)FrooxEngine.Store.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Core">
-      <HintPath>$(GameRefsPath)Elements.Core.dll</HintPath>
+      <HintPath>$(GamePath)Elements.Core.dll</HintPath>
+    </Reference>
+	<Reference Include="Renderite.Shared">
+      <HintPath>$(GamePath)Renderite.Shared.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Should fix building issues for Net9 and the splitting as some types like Chirality and Color have been moved to Renderite.Shared